### PR TITLE
Fix util/install_fec_data script

### DIFF
--- a/utils/install_fec_data.sh
+++ b/utils/install_fec_data.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-wget https://www.fec.gov/files/bulk-downloads/2018/indiv18.zip &&
+curl -L -O https://www.fec.gov/files/bulk-downloads/2018/indiv18.zip &&
 unzip -p indiv18 itcont.txt | head -n 18245416 > itcont.txt &&
 rm indiv18.zip &&
-mv itcont.txt ./data/
+mkdir -p ./data/indiv18 &&
+mv itcont.txt ./data/indiv18/


### PR DESCRIPTION
- use `curl` to download the data file. 

`wget` isn't installed by default in macOS, while `curl` is. I believe the same might be true for other systems.

- `run.sh` assumes data file is in `data/indiv18/` directory